### PR TITLE
Prerenderizar pagina 404

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -2,6 +2,7 @@
 import Layout from "../layouts/Layout.astro"
 import Loading from "../components/assets/Loading.svg"
 
+export const prerender = true
 ---
 
 <Layout>


### PR DESCRIPTION
This pull request includes a small change to the `src/pages/404.astro` file. The change adds a `prerender` export to enable static generation of the 404 page.